### PR TITLE
Added German translation

### DIFF
--- a/i18n/translations_de.ts
+++ b/i18n/translations_de.ts
@@ -1,0 +1,251 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.0" language="sv_SE">
+<context>
+    <name>AboutPage</name>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="25"/>
+        <source>Change toolbar</source>
+        <translation>Werkzeugleiste anpassen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="26"/>
+        <source>Draw freehand line</source>
+        <translation>Freihandlinie zeichnen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="27"/>
+        <source>Eraser</source>
+        <translation>Radierer</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="28"/>
+        <source>Sprayer</source>
+        <translation>Airbrush</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="29"/>
+        <source>Draw geometric shape</source>
+        <translation>Form zeichnen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="30"/>
+        <source>Change color, width</source>
+        <translation>Farbe/Stärke anpassen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="31"/>
+        <source>Draw line</source>
+        <translation>Linie zeichnen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="32"/>
+        <source>Draw rectangle</source>
+        <translation>Rechteck zeichnen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="33"/>
+        <source>Draw filled rectangle</source>
+        <translation>Gefülltes Rechteck zeichnen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="34"/>
+        <source>Draw circle</source>
+        <translation>Kreis zeichnen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="35"/>
+        <source>Draw filled circle</source>
+        <translation>Gefüllten Kreis zeichnen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="36"/>
+        <source>About Paint</source>
+        <translation>Über Paint</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="37"/>
+        <source>Change settings</source>
+        <translation>Einstellungen ändern</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="38"/>
+        <source>Clear drawing</source>
+        <translation>Zeichnung leeren</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="39"/>
+        <source>Change bacground</source>
+        <translation>Hintergrund anpassen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="40"/>
+        <source>Save snapshot</source>
+        <translation>Schnappschuss speichern</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="57"/>
+        <source>About </source>
+        <translation>Über </translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="95"/>
+        <source>Version: </source>
+        <translation>Version: </translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="103"/>
+        <source>Swedish translation by Åke Engelbrektson</source>
+        <translation>Schwedische Übersetzung von Åke Engelbrektson</translation>
+    </message>
+	<message>
+        <location filename="../qml/pages/AboutPage.qml" line="103"/>
+        <source>German translation by Jens Klingen</source>
+        <translation>Deutsche Übersetzung von Jens Klingen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="110"/>
+        <source>Help</source>
+        <translation>Hilfe</translation>
+    </message>
+</context>
+<context>
+    <name>Toolbar2</name>
+    <message>
+        <location filename="../qml/components/Toolbar2.qml" line="40"/>
+        <source>File format</source>
+        <translation>Dateiformat</translation>
+    </message>
+</context>
+<context>
+    <name>Toolbox</name>
+    <message>
+        <location filename="../qml/components/Toolbox.qml" line="23"/>
+        <source>Clearing</source>
+        <translation>Leeren</translation>
+    </message>
+</context>
+<context>
+    <name>bgSettingsDialog</name>
+    <message>
+        <location filename="../qml/pages/bgSettingsDialog.qml" line="14"/>
+        <source>Select background</source>
+        <translation>Hintergrund auswählen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/bgSettingsDialog.qml" line="28"/>
+        <source>Select color</source>
+        <translation>Farbe auswählen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/bgSettingsDialog.qml" line="64"/>
+        <source>None</source>
+        <translation>Keine</translation>
+    </message>
+</context>
+<context>
+    <name>eraserSettingsDialog</name>
+    <message>
+        <location filename="../qml/pages/eraserSettingsDialog.qml" line="23"/>
+        <source>Eraser settings</source>
+        <translation>Radierer-Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/eraserSettingsDialog.qml" line="37"/>
+        <source>Eraser size</source>
+        <translation>Radierer-Breite</translation>
+    </message>
+</context>
+<context>
+    <name>genSettings</name>
+    <message>
+        <location filename="../qml/pages/genSettings.qml" line="15"/>
+        <source>General settings</source>
+        <translation>Allgemeine Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/genSettings.qml" line="29"/>
+        <source>File format</source>
+        <translation>Dateiformat</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/genSettings.qml" line="67"/>
+        <source>Toolbox location</source>
+        <translation>Position der Werkzeugleiste</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/genSettings.qml" line="77"/>
+        <source>Top</source>
+        <translation>Oben</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/genSettings.qml" line="91"/>
+        <source>Bottom</source>
+        <translation>Unten</translation>
+    </message>
+</context>
+<context>
+    <name>paint</name>
+    <message>
+        <location filename="../qml/paint.qml" line="13"/>
+        <source>Accept</source>
+        <translation>Annehmen</translation>
+    </message>
+    <message>
+        <location filename="../qml/paint.qml" line="14"/>
+        <source>Cancel</source>
+        <translation>Abbrechen</translation>
+    </message>
+</context>
+<context>
+    <name>penSettingsDialog</name>
+    <message>
+        <location filename="../qml/pages/penSettingsDialog.qml" line="24"/>
+        <source>Pen settings</source>
+        <translation>Zeichenstift-Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/penSettingsDialog.qml" line="38"/>
+        <source>Select color</source>
+        <translation>Farbe auswählen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/penSettingsDialog.qml" line="73"/>
+        <source>Pen width</source>
+        <translation>Linienstärke</translation>
+    </message>
+</context>
+<context>
+    <name>spraySettingsDialog</name>
+    <message>
+        <location filename="../qml/pages/spraySettingsDialog.qml" line="65"/>
+        <source>Sprayer settings</source>
+        <translation>Airbrush-Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/spraySettingsDialog.qml" line="72"/>
+        <source>Select color</source>
+        <translation>Farbe auswählen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/spraySettingsDialog.qml" line="146"/>
+        <source>Sprayer parameters</source>
+        <translation>Airbrush-Parameter</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/spraySettingsDialog.qml" line="152"/>
+        <source>Size</source>
+        <translation>Größe</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/spraySettingsDialog.qml" line="165"/>
+        <source>Density</source>
+        <translation>Dichte</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/spraySettingsDialog.qml" line="179"/>
+        <source>Particle size</source>
+        <translation>Partikelgröße</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Thanks for the nice app, great job :)

So here's the German translation. 

Notes:
- There's a typo in the English version: "Change bacground", should be "Change background"
- I am not sure what you are planning to do with the "... translation by ..." messages in the About dialog. So i just added an additional message for the German translation and also translated the one for the Swedish translation, but I did not add another Label for it. Best idea might be to just display the translator for the currently active locale. Otherwise translators will end up meta-translating all other translators.

Best regards,
Jens :)
