### PR TITLE
Minor improvement for German translation

### DIFF
--- a/i18n/translations_de.ts
+++ b/i18n/translations_de.ts
@@ -383,7 +383,7 @@
     <message>
         <location filename="../qml/pages/textSettingsDialog.qml" line="128"/>
         <source>Font</source>
-        <translation>Schrift</translation>
+        <translation>Schriftart</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
Changed "Schrift" to "Schriftart"
In German, font face is more commonly referred to as "Schriftart", while "Schrift" is more like "[the] writing".
